### PR TITLE
Prevent duplicating assembly info attributes

### DIFF
--- a/Asterisk.2013/Asterisk.NET/AsterNET.csproj
+++ b/Asterisk.2013/Asterisk.NET/AsterNET.csproj
@@ -11,6 +11,7 @@
     <Description>AsterNET an Asterisk FastAGI and AMI framework for .NET</Description>
     <PackageReleaseNotes>Please see: https://github.com/AsterNET/AsterNET/commits/master</PackageReleaseNotes>
     <Configurations>Debug;Release;Travis</Configurations>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
```
Asterisk.NET/obj/Debug/netstandard2.0/AsterNET.AssemblyInfo.cs(13,12): error CS0579: Duplicate 'System.Reflection.AssemblyCompanyAttribute' attribute
Asterisk.NET/obj/Debug/netstandard2.0/AsterNET.AssemblyInfo.cs(14,12): error CS0579: Duplicate 'System.Reflection.AssemblyConfigurationAttribute' attribute
Asterisk.NET/obj/Debug/netstandard2.0/AsterNET.AssemblyInfo.cs(15,12): error CS0579: Duplicate 'System.Reflection.AssemblyCopyrightAttribute' attribute
Asterisk.NET/obj/Debug/netstandard2.0/AsterNET.AssemblyInfo.cs(16,12): error CS0579: Duplicate 'System.Reflection.AssemblyDescriptionAttribute' attribute
Asterisk.NET/obj/Debug/netstandard2.0/AsterNET.AssemblyInfo.cs(17,12): error CS0579: Duplicate 'System.Reflection.AssemblyFileVersionAttribute' attribute
Asterisk.NET/obj/Debug/netstandard2.0/AsterNET.AssemblyInfo.cs(19,12): error CS0579: Duplicate 'System.Reflection.AssemblyProductAttribute' attribute
Asterisk.NET/obj/Debug/netstandard2.0/AsterNET.AssemblyInfo.cs(20,12): error CS0579: Duplicate 'System.Reflection.AssemblyTitleAttribute' attribute
Asterisk.NET/obj/Debug/netstandard2.0/AsterNET.AssemblyInfo.cs(21,12): error CS0579: Duplicate 'System.Reflection.AssemblyVersionAttribute' attribute
```